### PR TITLE
Fixed checking for existing installation

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -170,7 +170,7 @@ checkAndUpdateSources() {
 
 checkExistingInstallAndDL() {
 	type=$1
-	if [[ -d ${USERDIR/ProjectAlice} ]]; then
+	if [[ -d ${USERDIR}/ProjectAlice ]]; then
 		echo
 		read -p $'\e[33mI have found existing directories where I should install. Shall I make a backup (y/n)? \e[0m' choice
 		case ${choice} in


### PR DESCRIPTION
Hi Everyone!

When running the installer for the first time, it mistakenly detects that ProjectAlice is already installed (and after asking to backup it, it fails to copy the non-existing files) because the /ProjectAlice suffix is inside the USERDIR variable brackets.